### PR TITLE
fix resolution of array values so that functions are not treated as arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ function createTaleRunner({ dispatch, getState }) {
         }
 
         // is array (wait for all)
-        if (value.length) {
+        if (Array.isArray(value) && value.length) {
             const newResult = new Array(value.length);
             const subTask = new Task();
             subTask.value = newResult;

--- a/test/call-apply.spec.js
+++ b/test/call-apply.spec.js
@@ -97,4 +97,55 @@ describe('call and apply', () => {
         expect(calledContext).toBe(context);
     });
 
+    it('call yields parameterless function', () => {
+        const func = () => {};
+        const toCall = () => func;
+        let resolvedValue;
+
+        function *test() {
+            resolvedValue = yield call(toCall);
+        }
+
+        taleMiddleware.run(test);
+        expect(resolvedValue).toEqual(func);
+    });
+
+    it('call yields function with parameters', () => {
+        const func = (a) => {};
+        const toCall = () => func;
+        let resolvedValue;
+
+        function *test() {
+            resolvedValue = yield call(toCall);
+        }
+
+        taleMiddleware.run(test);
+        expect(resolvedValue).toEqual(func);
+    });
+
+    it('call yields empty array', () => {
+        const array = [];
+        const toCall = () => array;
+        let resolvedValue;
+
+        function *test() {
+            resolvedValue = yield call(toCall);
+        }
+
+        taleMiddleware.run(test);
+        expect(resolvedValue).toEqual(array);
+    });
+
+    it('call yields array with values', () => {
+        const array = [1, 2, 3];
+        const toCall = () => array;
+        let resolvedValue;
+
+        function *test() {
+            resolvedValue = yield call(toCall);
+        }
+
+        taleMiddleware.run(test);
+        expect(resolvedValue).toEqual(array);
+    });
 });


### PR DESCRIPTION
Currently `value.length` is used to detect if value is an array which means functions with non-empty parameters get treated as arrays too. This change adds this check `Array.isArray(value)` making functions pass through as raw values.