### PR TITLE
Misc error handling

### DIFF
--- a/src/action-emitter.js
+++ b/src/action-emitter.js
@@ -1,4 +1,5 @@
 import { getPatternChecker } from './pattern-checker';
+import { logError } from './log-error';
 
 /**
  * Fires take's when an action matches
@@ -33,18 +34,14 @@ export function makeActionEmitter() {
             // this means that if an action is taken by two sagas and one of those
             // sagas emits an action taken by the 2nd saga, it will not pick it up
             // since it will process the previous action *afterwards*
-            let firstThrown;
             for (let i = 0; i < listenersToFire.length; i++) {
 
                 // callback follow redux-tale callback format isThrown, value
                 try {
                     listenersToFire[i].callback(false, action);
                 } catch (e) {
-                    firstThrown = firstThrown || e;
+                    logError(e);
                 }
-            }
-            if (firstThrown) {
-                throw firstThrown;
             }
         },
     };

--- a/src/action-emitter.js
+++ b/src/action-emitter.js
@@ -33,10 +33,18 @@ export function makeActionEmitter() {
             // this means that if an action is taken by two sagas and one of those
             // sagas emits an action taken by the 2nd saga, it will not pick it up
             // since it will process the previous action *afterwards*
+            let firstThrown;
             for (let i = 0; i < listenersToFire.length; i++) {
 
                 // callback follow redux-tale callback format isThrown, value
-                listenersToFire[i].callback(false, action);
+                try {
+                    listenersToFire[i].callback(false, action);
+                } catch (e) {
+                    firstThrown = firstThrown || e;
+                }
+            }
+            if (firstThrown) {
+                throw firstThrown;
             }
         },
     };

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,3 +1,5 @@
+import { logError } from './log-error';
+
 export const CALL = 'CALL';
 export function call(func, ...args) {
     let context = undefined;
@@ -33,31 +35,9 @@ export function take(pattern) {
     };
 }
 
-function getErrorObject(value) {
-    if (value && value.stack) {
-        return {
-            message: 'Unhandled exception in tale: ' + value,
-            stack: value.stack,
-        };
-    }
-
-    if (typeof value === 'object') {
-        return {
-            message: 'Unhandled exception in tale: ' + JSON.stringify(value),
-        };
-    }
-
-    return {
-        message: 'Unhandled exception in tale: ' + value,
-    };
-}
-
 function onTaskCatchError(isThrown, value) {
-    if (isThrown && window.onerror) {
-        // set timeout since jasmine doesn't expect window.onerror to be called from its own context
-        setTimeout(() => {
-            window.onerror(getErrorObject(value));
-        });
+    if (isThrown) {
+        logError(value);
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -62,33 +62,40 @@ function createTaleRunner({ dispatch, getState }) {
     }
 
     function resolveEffect(value, task, makeCallback, callbackArg) {
-        if (value.__reduxTaleType === effects.TAKE) {
-            actionEmitter.take(value.pattern, makeCallback(task, callbackArg));
-            return false;
-        }
-
-        if (value.__reduxTaleType === effects.SPAWN) {
-            return { value: runGenObj(value.worker(...value.args)) };
-        }
-
-        if (value.__reduxTaleType === effects.SELECT) {
-            const state = getState();
-            if (value.selector) {
-                return { value: value.selector(state, ...value.args) };
+        try {
+            if (value.__reduxTaleType === effects.TAKE) {
+                actionEmitter.take(value.pattern, makeCallback(task, callbackArg));
+                return false;
             }
-            return { value: state };
-        }
 
-        if (value.__reduxTaleType === effects.PUT) {
-            return { value: dispatch(value.action) };
-        }
+            if (value.__reduxTaleType === effects.SPAWN) {
+                return { value: runGenObj(value.worker(...value.args)) };
+            }
 
-        if (value.__reduxTaleType === effects.CALL) {
-            return resolveValue(value.func.apply(value.context, value.args), task, makeCallback, callbackArg);
-        }
+            if (value.__reduxTaleType === effects.SELECT) {
+                const state = getState();
+                if (value.selector) {
+                    return { value: value.selector(state, ...value.args) };
+                }
+                return { value: state };
+            }
 
-        if (value.__reduxTaleType === effects.RACE) {
-            return handleRaceEffect(value, task, runGenObj, makeCallback, callbackArg);
+            if (value.__reduxTaleType === effects.PUT) {
+                return { value: dispatch(value.action) };
+            }
+
+            if (value.__reduxTaleType === effects.CALL) {
+                return resolveValue(value.func.apply(value.context, value.args), task, makeCallback, callbackArg);
+            }
+
+            if (value.__reduxTaleType === effects.RACE) {
+                return handleRaceEffect(value, task, runGenObj, makeCallback, callbackArg);
+            }
+        } catch (e) {
+            return {
+                thrown: true,
+                value: e,
+            };
         }
 
         throw new Error('unrecognised redux tale effect');

--- a/src/log-error.js
+++ b/src/log-error.js
@@ -1,0 +1,27 @@
+function getErrorObject(value) {
+    if (value && value.stack) {
+        return {
+            message: 'Unhandled exception in tale: ' + value,
+            stack: value.stack,
+        };
+    }
+
+    if (typeof value === 'object') {
+        return {
+            message: 'Unhandled exception in tale: ' + JSON.stringify(value),
+        };
+    }
+
+    return {
+        message: 'Unhandled exception in tale: ' + value,
+    };
+}
+
+export function logError(error) {
+    if (window.onerror) {
+        // set timeout since jasmine doesn't expect window.onerror to be called from its own context
+        setTimeout(() => {
+            window.onerror(getErrorObject(error));
+        });
+    }
+}

--- a/test/action-emitter.spec.js
+++ b/test/action-emitter.spec.js
@@ -3,9 +3,12 @@ import { makeActionEmitter } from '../src/action-emitter';
 describe('emitter', () => {
 
     let actionEmitter;
+    let onerror;
 
     beforeEach(() => {
         actionEmitter = makeActionEmitter();
+        onerror = jest.fn();
+        window.onerror = onerror;
     });
 
     it('fires events', () => {
@@ -116,26 +119,21 @@ describe('emitter', () => {
 
         const listener1 = jest.fn(() => { throw new Error(); });
         const listener2 = jest.fn();
+        const listener3 = jest.fn(() => { throw new Error(); });
 
         actionEmitter.take('*', listener1);
         actionEmitter.take('*', listener2);
+        actionEmitter.take('*', listener3);
 
-        let thrownCount = 0;
-        try {
-            actionEmitter.emit(1);
-        } catch (e) {
-            thrownCount++;
-        }
+        actionEmitter.emit(1);
+        jest.runAllTimers();
 
         expect(listener1).toHaveBeenCalledTimes(1);
         expect(listener1).toHaveBeenLastCalledWith(false, 1);
         expect(listener2).toHaveBeenCalledTimes(1);
         expect(listener2).toHaveBeenLastCalledWith(false, 1);
-        expect(thrownCount).toBe(1);
-
-        actionEmitter.emit(2);
-
-        expect(listener1).toHaveBeenCalledTimes(1);
-        expect(listener2).toHaveBeenCalledTimes(1);
+        expect(listener3).toHaveBeenCalledTimes(1);
+        expect(listener3).toHaveBeenLastCalledWith(false, 1);
+        expect(onerror).toHaveBeenCalledTimes(2);
     });
 });

--- a/test/action-emitter.spec.js
+++ b/test/action-emitter.spec.js
@@ -111,4 +111,31 @@ describe('emitter', () => {
         expect(listener1Calls).toEqual(0);
         expect(listener2Calls).toEqual(1);
     });
+
+    it('fires events even when listeners throw', () => {
+
+        const listener1 = jest.fn(() => { throw new Error(); });
+        const listener2 = jest.fn();
+
+        actionEmitter.take('*', listener1);
+        actionEmitter.take('*', listener2);
+
+        let thrownCount = 0;
+        try {
+            actionEmitter.emit(1);
+        } catch (e) {
+            thrownCount++;
+        }
+
+        expect(listener1).toHaveBeenCalledTimes(1);
+        expect(listener1).toHaveBeenLastCalledWith(false, 1);
+        expect(listener2).toHaveBeenCalledTimes(1);
+        expect(listener2).toHaveBeenLastCalledWith(false, 1);
+        expect(thrownCount).toBe(1);
+
+        actionEmitter.emit(2);
+
+        expect(listener1).toHaveBeenCalledTimes(1);
+        expect(listener2).toHaveBeenCalledTimes(1);
+    });
 });

--- a/test/call-apply.spec.js
+++ b/test/call-apply.spec.js
@@ -148,4 +148,20 @@ describe('call and apply', () => {
         taleMiddleware.run(test);
         expect(resolvedValue).toEqual(array);
     });
+
+    it('call throws if callee throws', () => {
+        const toCall = () => { throw new Error(); };
+        let didThrow = false;
+
+        function *test() {
+            try {
+                yield call(toCall);
+            } catch (e) {
+                didThrow = true;
+            }
+        }
+
+        taleMiddleware.run(test);
+        expect(didThrow).toBe(true);
+    });
 });

--- a/test/log-error.spec.js
+++ b/test/log-error.spec.js
@@ -1,0 +1,60 @@
+import { logError } from '../src/log-error';
+
+describe('log-error', () => {
+
+    let onerror;
+
+    beforeEach(() => {
+        onerror = jest.fn();
+        window.onerror = onerror;
+    });
+
+    it('logs an error', () => {
+        const error = new Error('test');
+        logError(error);
+        jest.runAllTimers();
+
+        expect(onerror).toHaveBeenCalledTimes(1);
+        expect(onerror).toHaveBeenLastCalledWith({
+            message: 'Unhandled exception in tale: ' + error,
+            stack: error.stack,
+        });
+    });
+
+    it('doesn\'t log if no window.onerror', () => {
+
+        window.onerror = undefined;
+        logError(new Error('test'));
+        jest.runAllTimers();
+
+        expect(onerror).toHaveBeenCalledTimes(0);
+    });
+
+    it('logs an object', () => {
+        const obj = {
+            a: 1,
+            b: 2,
+            c: {
+                d: 4,
+            },
+        };
+
+        logError(obj);
+        jest.runAllTimers();
+
+        expect(onerror).toHaveBeenCalledTimes(1);
+        expect(onerror).toHaveBeenLastCalledWith({
+            message: 'Unhandled exception in tale: ' + JSON.stringify(obj),
+        });
+    });
+
+    it('logs a primitive', () => {
+        logError(1);
+        jest.runAllTimers();
+
+        expect(onerror).toHaveBeenCalledTimes(1);
+        expect(onerror).toHaveBeenLastCalledWith({
+            message: 'Unhandled exception in tale: ' + 1,
+        });
+    });
+});

--- a/test/put.spec.js
+++ b/test/put.spec.js
@@ -27,4 +27,31 @@ describe('put', () => {
         taleMiddleware.run(test);
         expect(store.getState()).toEqual(newState);
     });
+
+    it('throws when put throws', () => {
+
+        const reducerError = new Error();
+        let thrown;
+
+        function *test() {
+            try {
+                yield put({ type: 'update-state' });
+            } catch (e) {
+                thrown = e;
+            }
+        }
+
+        store = createStore(
+            (action) => {
+                if (action) {
+                    throw reducerError;
+                }
+                return {};
+            },
+            applyMiddleware(taleMiddleware)
+        );
+
+        taleMiddleware.run(test);
+        expect(thrown).toEqual(reducerError);
+    });
 });

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -55,4 +55,23 @@ describe('select', () => {
         taleMiddleware.run(test);
         expect(order).toEqual([1, 2]);
     });
+
+    it('throws if a selector throws', () => {
+        const order = [];
+        let didThrow = false;
+
+        function *test() {
+            try {
+                order.push(yield select((state) => state.a.b.c));
+            } catch (e) {
+                didThrow = true;
+            }
+        }
+
+        newState = { a: 1 };
+        store.dispatch({ type: 'update-state' });
+        taleMiddleware.run(test);
+        expect(order).toEqual([]);
+        expect(didThrow).toBe(true);
+    });
 });


### PR DESCRIPTION
Currently errors in effects, e.g. if a reducer throws in a put, cause an unhanded error that causes the saga to terminate. Any other sagas that have matched the same pattern and are still waiting to run in action-emitter will also not be run,

This change makes effects throw in the yielding saga so they are handled by the existing takeEvery worker spawning.  The action-emitter callbacks are now also isolated in a try catch. 