### PR TITLE
Error logging within setTimeout causing tests to succeed even when errors were thrown.

### DIFF
--- a/src/log-error.js
+++ b/src/log-error.js
@@ -19,9 +19,6 @@ function getErrorObject(value) {
 
 export function logError(error) {
     if (window.onerror) {
-        // set timeout since jasmine doesn't expect window.onerror to be called from its own context
-        setTimeout(() => {
-            window.onerror(getErrorObject(error));
-        });
+        window.onerror(getErrorObject(error));
     }
 }

--- a/test/exceptions.spec.js
+++ b/test/exceptions.spec.js
@@ -146,8 +146,6 @@ describe('exceptions', () => {
         store.dispatch({
             type: 1,
         });
-        expect(onerror).not.toHaveBeenCalled();
-        jest.runAllTimers();
         expect(onerror).toHaveBeenCalledWith({
             message: 'Unhandled exception in tale: Error: an error',
             stack: exception.stack,
@@ -168,8 +166,6 @@ describe('exceptions', () => {
         store.dispatch({
             type: 1,
         });
-        expect(onerror).not.toHaveBeenCalled();
-        jest.runAllTimers();
         expect(onerror).toHaveBeenCalledWith({
             message: 'Unhandled exception in tale: {"a":1,"b":2}',
         });
@@ -186,8 +182,6 @@ describe('exceptions', () => {
         store.dispatch({
             type: 1,
         });
-        expect(onerror).not.toHaveBeenCalled();
-        jest.runAllTimers();
         expect(onerror).toHaveBeenCalledWith({
             message: 'Unhandled exception in tale: error',
         });

--- a/test/take-every.spec.js
+++ b/test/take-every.spec.js
@@ -145,8 +145,6 @@ describe('take-every', () => {
         store.dispatch({
             type: 2,
         });
-        expect(onerror).toHaveBeenCalledTimes(0);
-        jest.runAllTimers();
         expect(onerror).toHaveBeenCalledTimes(2);
     });
 
@@ -168,8 +166,6 @@ describe('take-every', () => {
         store.dispatch({
             type: 2,
         });
-        expect(onerror).toHaveBeenCalledTimes(0);
-        jest.runAllTimers();
         expect(onerror).toHaveBeenCalledTimes(1);
         expect(order).toEqual([{
             type: 2,

--- a/test/take-latest.spec.js
+++ b/test/take-latest.spec.js
@@ -60,8 +60,6 @@ describe('take-every', () => {
         store.dispatch({
             type: 2,
         });
-        expect(onerror).toHaveBeenCalledTimes(0);
-        jest.runAllTimers();
         expect(onerror).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
Calling `window.onerror` within `setTimeout` can lead to unexpected results when testing sagas with `redux-tale`.
When the tester uses `jest.clearAllTimers()` in the `afterAll/Each` section or any other helper that clears pending timers, the error will never be thrown. This means all run time exceptions that happen within sagas are swallowed and it's really hard to debug failing tests. 

The comment about the setTimeout doesn't give enough information about the issue, so I couldn't really find out what the real problem was when the delay was introduced.