### PR TITLE
Detection of potentially-unhandled actions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+#### v1.4.0
+* Detection of potentially-unhandled actions
+
 #### v1.3.1
 
 * Support toolkit actions in pattern matching arrays

--- a/src/action-emitter.js
+++ b/src/action-emitter.js
@@ -33,7 +33,7 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
                 }
             }
 
-            if (listenersToFire.every(({ pattern }) => pattern === '*' || pattern.ignoreForUnhandledActionDetection)) {
+            if (listenersToFire.every(({ pattern }) => pattern === '*' || pattern.isLoose)) {
                 onPotentiallyUnhandledAction(action);
             }
 
@@ -64,7 +64,7 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
  * @returns marked matcher
  */
 export function patternMatcherChoosy(matcher) {
-    matcher.ignoreForUnhandledActionDetection = false;
+    matcher.isLoose = false;
 
     return matcher;
 }
@@ -79,7 +79,7 @@ export function patternMatcherChoosy(matcher) {
  * @returns marked matcher
  */
 export function patternMatcherLoose(matcher) {
-    matcher.ignoreForUnhandledActionDetection = true;
+    matcher.isLoose = true;
 
     return matcher;
 }

--- a/src/action-emitter.js
+++ b/src/action-emitter.js
@@ -15,7 +15,7 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
                 pattern,
                 pattern2ndArg,
                 patternChecker: getPatternChecker(pattern, pattern2ndArg),
-                isPicky: isPickyPattern(pattern),
+                isChoosy: isChoosyPattern(pattern),
                 callback,
             });
         },
@@ -34,7 +34,7 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
                 }
             }
 
-            if (!listenersToFire.some((listener) => listener.isPicky)) {
+            if (!listenersToFire.some((listener) => listener.isChoosy)) {
                 onPotentiallyUnhandledAction(action);
             }
 
@@ -55,6 +55,6 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
     };
 }
 
-function isPickyPattern(pattern) {
-    return pattern !== '*' && pattern.isPicky !== false;
+function isChoosyPattern(pattern) {
+    return pattern !== '*' && pattern.isChoosy !== false;
 }

--- a/src/action-emitter.js
+++ b/src/action-emitter.js
@@ -36,7 +36,7 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
                 }
             }
 
-            if (!listenersToFire.some((listener) => listener.isChoosy)) {
+            if (listenersToFire.every((listener) => listener.ignoreForUnhandledActionDetection)) {
                 onPotentiallyUnhandledAction(action);
             }
 

--- a/src/action-emitter.js
+++ b/src/action-emitter.js
@@ -11,11 +11,13 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
     const listeners = [];
     return {
         take(pattern, pattern2ndArg, callback) {
+            const ignoreForUnhandledActionDetection = pattern === '*' || pattern.ignoreForUnhandledActionDetection;
+
             listeners.push({
                 pattern,
                 pattern2ndArg,
                 patternChecker: getPatternChecker(pattern, pattern2ndArg),
-                isChoosy: isChoosyPattern(pattern),
+                ignoreForUnhandledActionDetection,
                 callback,
             });
         },
@@ -53,8 +55,4 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
             }
         },
     };
-}
-
-function isChoosyPattern(pattern) {
-    return pattern !== '*' && pattern.isChoosy !== false;
 }

--- a/src/action-emitter.js
+++ b/src/action-emitter.js
@@ -56,3 +56,33 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
         },
     };
 }
+
+/**
+ * Marks the given matcher as one that does count for unhandled action detection.
+ * Only matchers that match a narrow range of actions should be annotated using this.
+ *
+ * @see patternMatcherLoose
+ *
+ * @param matcher
+ * @returns marked matcher
+ */
+export function patternMatcherChoosy(matcher) {
+    matcher.ignoreForUnhandledActionDetection = false;
+
+    return matcher;
+}
+
+/**
+ * Marks the given matcher as one to be ignored for unhandled action detection.
+ * Matchers that match a wide range of actions must be marked using this.
+ *
+ * @see patternMatcherChoosy
+ *
+ * @param matcher
+ * @returns marked matcher
+ */
+export function patternMatcherLoose(matcher) {
+    matcher.ignoreForUnhandledActionDetection = true;
+
+    return matcher;
+}

--- a/src/action-emitter.js
+++ b/src/action-emitter.js
@@ -11,13 +11,10 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
     const listeners = [];
     return {
         take(pattern, pattern2ndArg, callback) {
-            const ignoreForUnhandledActionDetection = pattern === '*' || pattern.ignoreForUnhandledActionDetection;
-
             listeners.push({
                 pattern,
                 pattern2ndArg,
                 patternChecker: getPatternChecker(pattern, pattern2ndArg),
-                ignoreForUnhandledActionDetection,
                 callback,
             });
         },
@@ -36,7 +33,7 @@ export function makeActionEmitter(onPotentiallyUnhandledAction) {
                 }
             }
 
-            if (listenersToFire.every((listener) => listener.ignoreForUnhandledActionDetection)) {
+            if (listenersToFire.every(({ pattern }) => pattern === '*' || pattern.ignoreForUnhandledActionDetection)) {
                 onPotentiallyUnhandledAction(action);
             }
 

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,3 +1,7 @@
+import { patternMatcherChoosy, patternMatcherLoose } from './action-emitter';
+
+export { patternMatcherChoosy, patternMatcherLoose };
+
 export const CALL = 'CALL';
 export function call(func, ...args) {
     let context = undefined;

--- a/src/index.js
+++ b/src/index.js
@@ -259,12 +259,11 @@ function createTaleRunner({ dispatch, getState, onPotentiallyUnhandledAction }) 
 /**
  * The redux middleware which is inserted to catch actions and give dispatch (put) and getState (select) capability
  *
- * [1] A "choosy" listener is a saga/take with a narrow interest of actions which it will process, for example one specific type of action.
- * All listener patterns except `*` are considered choosy be default. Patterns can be marked as not-choosy by giving them a property `isChoosy = false`.
- *
  * @param {Object} [options]
- * @param {onPotentiallyUnhandledAction} [options.onPotentiallyUnhandledAction] Called when no choosy listener [1] processed an action.
+ * @param {onPotentiallyUnhandledAction} [options.onPotentiallyUnhandledAction] Called when no listener processed an action.
  *      Use it to help detect circumstances where no saga was running to process a dispatched action intended for it.
+ *      Listeners with a broad interest of actions must be ignored, otherwise many/all actions will always be considered handled.
+ *      Mark listeners using the helper `patternMatcherLoose(matcher)` to ignore them. The `*` pattern is always ignored.
  */
 export default function createTaleMiddleware(options = {}) {
     options.onPotentiallyUnhandledAction = options.onPotentiallyUnhandledAction || function noop() {};

--- a/src/index.js
+++ b/src/index.js
@@ -262,7 +262,8 @@ function createTaleRunner({ dispatch, getState, onPotentiallyUnhandledAction }) 
  * @param {onPotentiallyUnhandledAction} [options.onPotentiallyUnhandledAction] Called when no listener processed an action.
  *      Use it to help detect circumstances where no saga was running to process a dispatched action intended for it.
  *      Listeners with a broad interest of actions must be ignored, otherwise many/all actions will always be considered handled.
- *      Mark listeners using the helper `patternMatcherLoose(matcher)` to ignore them. The `*` pattern is always ignored.
+ *      Mark listener patterns with a property `isLoose = true` (or use the helper `patternMatcherLoose(matcher)`) to ignore them.
+ *      The `*` pattern is always ignored.
  */
 export default function createTaleMiddleware(options = {}) {
     options.onPotentiallyUnhandledAction = options.onPotentiallyUnhandledAction || function noop() {};

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,11 @@ import * as effects from './effects';
 import Task from './task';
 import delay from './delay';
 import { handleRaceEffect } from './race';
-import { makeActionEmitter, patternMatcherChoosy, patternMatcherLoose } from './action-emitter';
+import { makeActionEmitter } from './action-emitter';
 import { logError } from './log-error';
 
 export { effects };
 export { delay };
-export { patternMatcherChoosy, patternMatcherLoose };
 
 function onTaskCatchError(isThrown, value) {
     if (isThrown) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,12 @@ import * as effects from './effects';
 import Task from './task';
 import delay from './delay';
 import { handleRaceEffect } from './race';
-import { makeActionEmitter } from './action-emitter';
+import { makeActionEmitter, patternMatcherChoosy, patternMatcherLoose } from './action-emitter';
 import { logError } from './log-error';
 
 export { effects };
 export { delay };
+export { patternMatcherChoosy, patternMatcherLoose };
 
 function onTaskCatchError(isThrown, value) {
     if (isThrown) {

--- a/src/index.js
+++ b/src/index.js
@@ -258,11 +258,11 @@ function createTaleRunner({ dispatch, getState, onPotentiallyUnhandledAction }) 
 /**
  * The redux middleware which is inserted to catch actions and give dispatch (put) and getState (select) capability
  *
- * [1] A "picky" listener is a saga/take with a narrow interest of actions which it will process, for example one specific type of action.
- * All listener patterns except `*` are considered picky be default. Patterns can be marked as not-picky by giving them a property `isPicky = false`.
+ * [1] A "choosy" listener is a saga/take with a narrow interest of actions which it will process, for example one specific type of action.
+ * All listener patterns except `*` are considered choosy be default. Patterns can be marked as not-choosy by giving them a property `isChoosy = false`.
  *
  * @param {Object} [options]
- * @param {onPotentiallyUnhandledAction} [options.onPotentiallyUnhandledAction] Called when no picky listener [1] processed an action.
+ * @param {onPotentiallyUnhandledAction} [options.onPotentiallyUnhandledAction] Called when no choosy listener [1] processed an action.
  *      Use it to help detect circumstances where no saga was running to process a dispatched action intended for it.
  */
 export default function createTaleMiddleware(options = {}) {

--- a/test/action-emitter.spec.js
+++ b/test/action-emitter.spec.js
@@ -153,9 +153,9 @@ describe('emitter', () => {
         expect(handlePotentiallyUnhandledAction).toBeCalled();
     });
 
-    it('unhandled actions: calls callback when the only listener\'s pattern matcher is marked ignored', () => {
+    it('unhandled actions: calls callback when the only listener\'s pattern matcher is marked as loose', () => {
         function patternMatcher(action) { return action.type !== 'match-everything-except-this'; }
-        patternMatcher.ignoreForUnhandledActionDetection = true;
+        patternMatcher.isLoose = true;
 
         actionEmitter.take(patternMatcher, undefined, function listener() {});
 

--- a/test/action-emitter.spec.js
+++ b/test/action-emitter.spec.js
@@ -153,9 +153,9 @@ describe('emitter', () => {
         expect(handlePotentiallyUnhandledAction).toBeCalled();
     });
 
-    it('unhandled actions: calls callback when the only listener\'s pattern matcher is specifically denoted as not-picky ', () => {
+    it('unhandled actions: calls callback when the only listener\'s pattern matcher is specifically denoted as not-choosy', () => {
         function patternMatcher(action) { return action.type !== 'match-everything-except-this'; }
-        patternMatcher.isPicky = false;
+        patternMatcher.isChoosy = false;
 
         actionEmitter.take(patternMatcher, undefined, function listener() {});
 
@@ -164,7 +164,7 @@ describe('emitter', () => {
         expect(handlePotentiallyUnhandledAction).toBeCalled();
     });
 
-    it('unhandled actions: doesnt call callback when a picky listener is present', () => {
+    it('unhandled actions: doesnt call callback when a choosy listener is present', () => {
         actionEmitter.take('foo', undefined, function listener() {});
         actionEmitter.take('*', undefined, function listener() {});
 

--- a/test/action-emitter.spec.js
+++ b/test/action-emitter.spec.js
@@ -164,7 +164,7 @@ describe('emitter', () => {
         expect(handlePotentiallyUnhandledAction).toBeCalled();
     });
 
-    it('unhandled actions: doesnt call callback when a non-ignored listener is present', () => {
+    it('unhandled actions: doesnt call callback when a non-loose listener is present', () => {
         actionEmitter.take('foo', undefined, function listener() {});
         actionEmitter.take('*', undefined, function listener() {});
 

--- a/test/action-emitter.spec.js
+++ b/test/action-emitter.spec.js
@@ -153,9 +153,9 @@ describe('emitter', () => {
         expect(handlePotentiallyUnhandledAction).toBeCalled();
     });
 
-    it('unhandled actions: calls callback when the only listener\'s pattern matcher is specifically denoted as not-choosy', () => {
+    it('unhandled actions: calls callback when the only listener\'s pattern matcher is marked ignored', () => {
         function patternMatcher(action) { return action.type !== 'match-everything-except-this'; }
-        patternMatcher.isChoosy = false;
+        patternMatcher.ignoreForUnhandledActionDetection = true;
 
         actionEmitter.take(patternMatcher, undefined, function listener() {});
 
@@ -164,7 +164,7 @@ describe('emitter', () => {
         expect(handlePotentiallyUnhandledAction).toBeCalled();
     });
 
-    it('unhandled actions: doesnt call callback when a choosy listener is present', () => {
+    it('unhandled actions: doesnt call callback when a non-ignored listener is present', () => {
         actionEmitter.take('foo', undefined, function listener() {});
         actionEmitter.take('*', undefined, function listener() {});
 


### PR DESCRIPTION
Some actions are used specifically for triggering sagas. If that saga is missing (e.g. not loaded in time) then they go unhandled which likely causes a tricky bug.

The middleware now accepts a listener for when this is detected, but leaves it up to app code to decide if the unhandled action is actually a problem and what to do about it.